### PR TITLE
index page를 index.md 대신 Home.md로 사용

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,7 @@ impl RustKrServer {
             self.show_not_found(req, res);
             return;
         }
-        self.handle_page("index", req, res);
+        self.handle_page("Home", req, res);
     }
 
     fn handle_page(&self, title: &str, req: Request, res: Response) {


### PR DESCRIPTION
github wiki는 무조건 Home.md를 생성하기 때문에 그 동작에 맞춤.